### PR TITLE
Fix generation

### DIFF
--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -35,7 +35,6 @@ class GenerateCommand extends BaseCommand {
   protected function execute(InputInterface $input, OutputInterface $output) {
     $config = [];
     $config['site'] = $input->getOption('site');
-    $config['template'] = '_blank';
     $web_root = getcwd();
 
     // Load Drupal package if avaiable and set webroot.
@@ -61,21 +60,32 @@ class GenerateCommand extends BaseCommand {
     $output_file = $web_root . '/sites/' . $config['site'] . '/settings.php';
     $template_source = '';
 
+    $local_default_template = dirname($web_root) . '/env-settings-template.php';
+    $druapl_default_template = $web_root . '/sites/default/default.settings.php';
+
     // If tempalte file exists, load the source from the file.
     if (!empty($input->getOption('template'))) {
       $config['template'] = $input->getOption('template');
     }
-    if (!isset($config['template']) || empty($config['template']) || $config['template'] === 'default') {
+
+    // If there is no template arguement attempt to load a default one.
+    if (!isset($config['template']) || empty($config['template']) || (isset($config['template']) && $config['template'] === 'default')) {
       // If template file isn't specified, use the example one.
-      if ($config['template'] !== 'default' && file_exists($output_file)) {
+      if ((!isset($config['template']) || $config['template'] !== 'default') && file_exists($output_file)) {
         // If the output file exists, use that instead.
         $config['template'] = $output_file;
       }
+      elseif (file_exists($local_default_template)) {
+        // Attempt to load a template from the root of the project, if provided.
+        $config['template'] = $local_default_template;
+      }
       else {
         // Otherwise, load the drupal example file.
-        $config['template'] = $web_root . '/sites/default/default.settings.php';
+        $config['template'] = $druapl_default_template;
       }
     }
+
+    // Load new source from template, if it exists.
     if ($config['template'] !== '_blank' && file_exists($config['template'])) {
       $template_source = file_get_contents($config['template']);
     }

--- a/src/SettingsGenerator/SettingsGenerator.php
+++ b/src/SettingsGenerator/SettingsGenerator.php
@@ -85,14 +85,33 @@ DOC_COMMENT_ENVIRONMENT;
     $this->generateVariableCode($code, $env_settings);
 
     // Ensure existance of output directory.
-    if (!file_exists($output_path)) {
-      mkdir(dirname($output_path), 0774, TRUE);
-    }
+    $this->mkdirRecursive(dirname($output_path));
 
     // Write setting file to filesystem.
     $prettyPrinter = new PrettyPrinter();
     $generated_source = $prettyPrinter->prettyPrintFile($code);
     file_put_contents($output_path, $generated_source);
+  }
+
+  /**
+   * Ensure that the settings directory exists.
+   *
+   * Recursively ensure that the settings directory exists, and create the
+   * directory and required parents if they are missing.
+   *
+   * @param string $path
+   *   Directory path name.
+   *
+   * @return boolean
+   *   True if directory exists or creation was successful. False otherwise.
+   */
+  protected function mkdirRecursive($path) {
+    if (is_dir($path)) {
+      return true;
+    }
+    $prev_path = dirname($path);
+    $can_create_next = $this->mkdirRecursive($prev_path) && is_writable($prev_path);
+    return ($can_create_next) ? mkdir($path, 0774, TRUE) : false;
   }
 
   /**

--- a/src/SettingsGenerator/SettingsGenerator.php
+++ b/src/SettingsGenerator/SettingsGenerator.php
@@ -90,6 +90,8 @@ DOC_COMMENT_ENVIRONMENT;
     // Write setting file to filesystem.
     $prettyPrinter = new PrettyPrinter();
     $generated_source = $prettyPrinter->prettyPrintFile($code);
+    // Add trailing newline for clean file printing.
+    $generated_source .= "\n";
     file_put_contents($output_path, $generated_source);
   }
 

--- a/src/SettingsGenerator/SettingsGenerator.php
+++ b/src/SettingsGenerator/SettingsGenerator.php
@@ -135,45 +135,63 @@ DOC_COMMENT_ENVIRONMENT;
     foreach ($env_settings as $name => $value) {
       $variable = new Variable($name);
       if (is_array($value)) {
-        // For nested arrays, with one value, use dim lookup format.
-        while (count($value) == 1) {
-          $value_keys = array_keys($value);
-          $key = array_shift($value_keys);
-          $variable = new ArrayDimFetch(
+        foreach($value as $dim => $sub_value) {
+          $sub_variable = new ArrayDimFetch(
             $variable,
-            $this->getAsScaler($key)
+            $this->getAsScaler($dim)
           );
-          $value = $value[$key];
+          // For nested arrays, with one value, use dim lookup format.
+          while (is_array($sub_value) && count($sub_value) == 1) {
+            $value_keys = array_keys($sub_value);
+            $key = array_shift($value_keys);
+            $sub_variable = new ArrayDimFetch(
+              $sub_variable,
+              $this->getAsScaler($key)
+            );
+            $sub_value = $sub_value[$key];
+          }
+          if (!is_array($sub_value)) {
+            // Non-array values are expected to be a environmental variable names.
+            $assigned_value = $this->buildGetEnvNode($sub_value);
+          }
+          else {
+            // An array at this point is multivalued.
+            // Each value needs to be expanded into possibly nested variables.
+            $assigned_value = $this->buildArrayItems($sub_value);
+          }
+          // Build line of configuration and add it to the file.
+          $code[] = new Expression(
+            new Assign(
+              $sub_variable,
+              $assigned_value
+            )
+          );
+        if ($first) {
+          $first = FALSE;
+          $last = array_pop($code);
+          $last->setAttribute('comments', [new Comment(static::DOC_COMMENT_ENVIRONMENT)]);
+          $code[] = $last;
         }
-
-        if (!is_array($value)) {
-          // Non-array values are expected to be a environmental variable names.
-          $assigned_value = $this->buildGetEnvNode($value);
-        }
-        else {
-          // An array at this point is multivalued.
-          // Each value needs to be expanded into possibly nested variables.
-          $assigned_value = $this->buildArrayItems($value);
         }
       }
       else {
         // Non-array values are expected to be a environmental variable names.
         $assigned_value = $this->buildGetEnvNode($value);
+        // Build line of configuration and add it to the file.
+        $code[] = new Expression(
+          new Assign(
+            $variable,
+            $assigned_value
+          )
+        );
+        if ($first) {
+          $first = FALSE;
+          $last = array_pop($code);
+          $last->setAttribute('comments', [new Comment(static::DOC_COMMENT_ENVIRONMENT)]);
+          $code[] = $last;
+        }
       }
 
-      // Build line of configuration and add it to the file.
-      $code[] = new Expression(
-        new Assign(
-          $variable,
-          $assigned_value
-        )
-      );
-      if ($first) {
-        $first = FALSE;
-        $last = array_pop($code);
-        $last->setAttribute('comments', [new Comment(static::DOC_COMMENT_ENVIRONMENT)]);
-        $code[] = $last;
-      }
     }
   }
 


### PR DESCRIPTION
Fix settings file generation.
1) Prevent overriding of non-managed settings.
2) Prevent logic for checking if output file exists (fixes exception on `mkdir()`)
3) Auto load template from root of project if no other template is provided as an option.
4) Add a newline to the generated source to comply with coding standards.